### PR TITLE
CAPI cluster template based on "Ubuntu 20.04" image for the "Hetzner" infrastructure provider

### DIFF
--- a/capi/infrastructure/templates/hetzner/cluster-template-ubuntu-20.04.yaml
+++ b/capi/infrastructure/templates/hetzner/cluster-template-ubuntu-20.04.yaml
@@ -1,0 +1,416 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: HetznerCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  hcloudNetwork:
+    enabled: false
+  controlPlaneRegions:
+    - "${HCLOUD_REGION}"
+  controlPlaneEndpoint:
+    host: ""
+    port: 443
+  controlPlaneLoadBalancer:
+    region: "${HCLOUD_REGION}"
+  hcloudPlacementGroups:
+    - name: control-plane
+      type: spread
+    - name: md-0
+      type: spread
+  sshKeys:
+    hcloud:
+      - name: "${HCLOUD_SSH_KEY}"
+  hetznerSecretRef:
+    name: hetzner
+    key:
+      hcloudToken: hcloud
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: HCloudMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          # CA certificate for validating API clients.
+          client-ca-file: /etc/kubernetes/pki/ca.crt # enable X509 Client Certs Auth
+          # TLS certificates for HTTPS serving.
+          tls-cert-file: /etc/kubernetes/pki/apiserver.crt
+          tls-private-key-file: /etc/kubernetes/pki/apiserver.key
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          # Required for kubelet communication.
+          kubelet-client-certificate: /etc/kubernetes/pki/apiserver-kubelet-client.crt
+          kubelet-client-key: /etc/kubernetes/pki/apiserver-kubelet-client.key
+          # Secure communication to etcd servers.
+          etcd-cafile: /etc/kubernetes/pki/etcd/ca.crt
+          etcd-certfile: /etc/kubernetes/pki/etcd/server.crt
+          etcd-keyfile: /etc/kubernetes/pki/etcd/server.key
+          # Required to validate service account tokens created by controller manager.
+          service-account-lookup: "true"
+          service-account-key-file: /etc/kubernetes/pki/sa.pub
+          # Required for aggregation layer
+          requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
+          proxy-client-key-file: /etc/kubernetes/pki/front-proxy-client.key
+          proxy-client-cert-file: /etc/kubernetes/pki/front-proxy-client.crt
+          requestheader-allowed-names: front-proxy-client
+          requestheader-extra-headers-prefix: X-Remote-Extra-
+          requestheader-group-headers: X-Remote-Group
+          requestheader-username-headers: X-Remote-User
+          enable-aggregator-routing: "true"
+          # Etcd Secret Encrytion
+          encryption-provider-config: /etc/kubernetes/encryption-provider.yaml
+          # Additional Configuration
+          cloud-provider: external
+          authorization-mode: "Node,RBAC"
+          kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
+          profiling: "false"
+          enable-bootstrap-token-auth: "true"
+          insecure-port: "0"
+          default-not-ready-toleration-seconds: "45"
+          default-unreachable-toleration-seconds: "45"
+        extraVolumes:
+          - name: encryption-provider
+            hostPath: /etc/kubernetes/encryption-provider.yaml
+            mountPath: /etc/kubernetes/encryption-provider.yaml
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+          cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
+          cluster-signing-key-file: /etc/kubernetes/pki/ca.key
+          cluster-signing-duration: 6h0m0s
+          terminated-pod-gc-threshold: "10"
+          profiling: "false"
+          use-service-account-credentials: "true"
+          service-account-private-key-file: /etc/kubernetes/pki/sa.key
+          root-ca-file: /etc/kubernetes/pki/ca.crt
+          requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
+          kubeconfig: /etc/kubernetes/controller-manager.conf
+          authentication-kubeconfig: /etc/kubernetes/controller-manager.conf
+          authorization-kubeconfig: /etc/kubernetes/controller-manager.conf
+          address: "127.0.0.1"
+          bind-address: "0.0.0.0"
+          port: "0"
+          secure-port: "10257"
+          allocate-node-cidrs: "true"
+          pod-eviction-timeout: 2m
+      scheduler:
+        extraArgs:
+          profiling: "false"
+          kubeconfig: /etc/kubernetes/scheduler.conf
+          address: "127.0.0.1"
+          bind-address: "0.0.0.0"
+          port: "0"
+          secure-port: "10259"
+      etcd:
+        local:
+          dataDir: /var/lib/etcd
+          extraArgs:
+            cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            cert-file: /etc/kubernetes/pki/etcd/server.crt
+            key-file: /etc/kubernetes/pki/etcd/server.key
+            client-cert-auth: "true"
+            auto-tls: "false"
+            peer-client-cert-auth: "true"
+            peer-auto-tls: "false"
+            trusted-ca-file: /etc/kubernetes/pki/etcd/ca.crt
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          kubeconfig: /etc/kubernetes/kubelet.conf
+          authentication-token-webhook: "true"
+          authorization-mode: Webhook
+          anonymous-auth: "false"
+          read-only-port: "0"
+          event-qps: "5"
+          rotate-server-certificates: "true"
+          max-pods: "120"
+          resolv-conf: /etc/kubernetes/resolv.conf
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          kubeconfig: /etc/kubernetes/kubelet.conf
+          authentication-token-webhook: "true"
+          authorization-mode: Webhook
+          anonymous-auth: "false"
+          read-only-port: "0"
+          event-qps: "5"
+          rotate-server-certificates: "true"
+          max-pods: "120"
+          resolv-conf: /etc/kubernetes/resolv.conf
+    files:
+      - path: /etc/docker/daemon.json
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          {
+            "exec-opts": ["native.cgroupdriver=systemd"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "100m"
+            },
+            "storage-driver": "overlay2"
+          }
+      - path: /etc/apt/sources.list.d/docker.list
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable
+      - path: /etc/apt/sources.list.d/kubernetes.list
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main
+      - path: /etc/kubernetes/encryption-provider.yaml
+        owner: "root:root"
+        permissions: "0600"
+        content: |
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: EncryptionConfiguration
+          resources:
+            - resources:
+              - secrets
+              providers:
+              - aescbc:
+                  keys:
+                  - name: key1
+                    secret: 8d7iAcg3/NwN9aijhtEXj5kL2NOHIgokGFjbIBfL6X0=
+              - identity: {}
+      - path: /etc/modules-load.d/kubernetes.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          overlay
+          br_netfilter
+      - path: /etc/sysctl.d/99-kubernetes-cri.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          net.bridge.bridge-nf-call-iptables  = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward                 = 1
+      - path: /etc/sysctl.d/99-kubelet.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          vm.overcommit_memory=1
+          kernel.panic=10
+          kernel.panic_on_oops=1
+      - path: /etc/kubernetes/resolv.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          nameserver 1.1.1.1
+          nameserver 1.0.0.1
+          nameserver 2606:4700:4700::1111
+    preKubeadmCommands:
+      - modprobe br_netfilter
+      - sysctl --system
+      - apt-get install -y apt-transport-https
+      - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+      - curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      - apt-get update -y
+      - apt-get install -y docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl
+      - systemctl enable docker
+      - systemctl daemon-reload
+      - systemctl restart docker
+  version: "${KUBERNETES_VERSION}"
+---
+kind: HCloudMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      type: "${HCLOUD_CONTROL_PLANE_MACHINE_TYPE}"
+      imageName: "ubuntu-20.04"
+      placementGroupName: control-plane
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-control-plane-unhealthy-5m"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 20m
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+  labels:
+    nodepool: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      failureDomain: "${HCLOUD_REGION}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: HCloudMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCloudMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      type: "${HCLOUD_WORKER_MACHINE_TYPE}"
+      imageName: "ubuntu-20.04"
+      placementGroupName: md-0
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            kubeconfig: /etc/kubernetes/kubelet.conf
+            authentication-token-webhook: "true"
+            authorization-mode: Webhook
+            anonymous-auth: "false"
+            read-only-port: "0"
+            event-qps: "5"
+            rotate-server-certificates: "true"
+            max-pods: "220"
+            resolv-conf: /etc/kubernetes/resolv.conf
+      files:
+        - path: /etc/docker/daemon.json
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            {
+              "exec-opts": ["native.cgroupdriver=systemd"],
+              "log-driver": "json-file",
+              "log-opts": {
+                "max-size": "100m"
+              },
+              "storage-driver": "overlay2"
+            }
+        - path: /etc/apt/sources.list.d/docker.list
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable
+        - path: /etc/apt/sources.list.d/kubernetes.list
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main
+        - path: /etc/modules-load.d/kubernetes.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            overlay
+            br_netfilter
+        - path: /etc/sysctl.d/99-kubernetes-cri.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            net.bridge.bridge-nf-call-iptables  = 1
+            net.bridge.bridge-nf-call-ip6tables = 1
+            net.ipv4.ip_forward                 = 1
+        - path: /etc/sysctl.d/99-kubelet.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            vm.overcommit_memory=1
+            kernel.panic=10
+            kernel.panic_on_oops=1
+        - path: /etc/kubernetes/resolv.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            nameserver 1.1.1.1
+            nameserver 1.0.0.1
+            nameserver 2606:4700:4700::1111
+      preKubeadmCommands:
+        - modprobe br_netfilter
+        - sysctl --system
+        - apt-get install -y apt-transport-https
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+        - curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        - apt-get update -y
+        - apt-get install -y docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl
+        - systemctl enable docker
+        - systemctl daemon-reload
+        - systemctl restart docker
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-0-unhealthy-5m"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 20m
+  selector:
+    matchLabels:
+      nodepool: "${CLUSTER_NAME}-md-0"
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s


### PR DESCRIPTION
Cluster template for automated provisioning of Kubernetes clusters using the "ubuntu-20.04" base image on "Hetzner Cloud" with the [Hetzner](https://github.com/syself/cluster-api-provider-hetzner) infrastructure provider for CAPI. Since we can not upload a pre-packaged image on "Hetzner Cloud" you can use this cluster-template to download, install and configure the following components prior to bootstrapping with the "kubeadm" provider:

- "Docker" runtime container engine
- "Kubernetes" with kubelet, kubectl, kubeadm

Usage:
```
clusterctl generate cluster development --from cluster-template-ubuntu-20.04.yaml
```